### PR TITLE
Introduce the ability to instruct the robot to move

### DIFF
--- a/src/main/java/com/stevanrose/martianrobots/Robot.java
+++ b/src/main/java/com/stevanrose/martianrobots/Robot.java
@@ -1,8 +1,10 @@
 package com.stevanrose.martianrobots;
 
 import com.stevanrose.martianrobots.exception.GridBoundaryException;
+import com.stevanrose.martianrobots.helper.RobotHelper;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.stevanrose.martianrobots.helper.RobotHelper.*;
 import static com.stevanrose.martianrobots.helper.RobotHelper.turnLeft;
 import static com.stevanrose.martianrobots.helper.RobotHelper.turnRight;
 
@@ -36,6 +38,11 @@ public class Robot {
       }
       if (command.equals("L")) {
         orientation = turnLeft(orientation);
+      }
+      if(command.equals("M")) {
+        Position newPosition = move(position, orientation);
+        position.setX(newPosition.getX());
+        position.setY(newPosition.getY());
       }
     }
     return report();

--- a/src/main/java/com/stevanrose/martianrobots/helper/RobotHelper.java
+++ b/src/main/java/com/stevanrose/martianrobots/helper/RobotHelper.java
@@ -1,6 +1,7 @@
 package com.stevanrose.martianrobots.helper;
 
 import com.stevanrose.martianrobots.Orientation;
+import com.stevanrose.martianrobots.Position;
 import lombok.experimental.UtilityClass;
 
 import java.util.AbstractMap;
@@ -29,5 +30,25 @@ public class RobotHelper {
 
   public static Orientation turnLeft(Orientation orientation) {
       return leftTurns.get(orientation);
+  }
+
+  public static Position move(Position position, Orientation orientation) {
+
+    Position nextPosition = new Position(position.getX(), position.getY());
+
+    if(orientation.equals(Orientation.N)) {
+      nextPosition.setY(position.getY() + 1);
+    }
+    if(orientation.equals(Orientation.E)) {
+      nextPosition.setX(position.getX() + 1);
+    }
+    if(orientation.equals(Orientation.S)) {
+      nextPosition.setY(position.getY() - 1);
+    }
+    if(orientation.equals(Orientation.W)) {
+      nextPosition.setX(position.getX() - 1);
+    }
+
+    return nextPosition;
   }
 }

--- a/src/test/java/com/stevanrose/martianrobots/RobotTest.java
+++ b/src/test/java/com/stevanrose/martianrobots/RobotTest.java
@@ -16,7 +16,7 @@ class RobotTest {
   @BeforeEach
   void setUp() {
     grid = new Grid(10, 10);
-    position = new Position(0, 0);
+    position = new Position(5, 5);
     robot = new Robot(grid, position, Orientation.N);
   }
 
@@ -36,46 +36,93 @@ class RobotTest {
 
   @Test
   void canCreateARobotAndReportCurrentPosition() {
-    assertEquals("0 0 N", robot.report());
+    assertEquals("5 5 N", robot.report());
   }
 
   @Test
   void canInstructRootToTurnToTheRightOnce() {
-    assertEquals("0 0 E", robot.execute("R"));
+    assertEquals("5 5 E", robot.execute("R"));
   }
 
   @Test
   void canInstructRootToTurnToTheRightTwice() {
-    assertEquals("0 0 S", robot.execute("RR"));
+    assertEquals("5 5 S", robot.execute("RR"));
   }
 
   @Test
   void canInstructRootToTurnToTheRightThreeTimes() {
-    assertEquals("0 0 W", robot.execute("RRR"));
+    assertEquals("5 5 W", robot.execute("RRR"));
   }
 
   @Test
   void canInstructRootToTurnToTheRightFourTimes() {
-    assertEquals("0 0 N", robot.execute("RRRR"));
+    assertEquals("5 5 N", robot.execute("RRRR"));
   }
 
   @Test
   void canInstructRootToTurnToTheLeftOnce() {
-    assertEquals("0 0 W", robot.execute("L"));
+    assertEquals("5 5 W", robot.execute("L"));
   }
 
   @Test
   void canInstructRootToTurnToTheLeftTwice() {
-    assertEquals("0 0 S", robot.execute("LL"));
+    assertEquals("5 5 S", robot.execute("LL"));
   }
 
   @Test
   void canInstructRootToTurnToTheLeftThreeTimes() {
-    assertEquals("0 0 E", robot.execute("LLL"));
+    assertEquals("5 5 E", robot.execute("LLL"));
   }
 
   @Test
   void canInstructRootToTurnToTheLeftFourTimes() {
-    assertEquals("0 0 N", robot.execute("LLLL"));
+    assertEquals("5 5 N", robot.execute("LLLL"));
   }
+
+  @Test
+  void canInstructRobotToMoveOneSpaceNorthWhilstRemainingInTheGrid() {
+    assertEquals("5 6 N", robot.execute("M"));
+  }
+
+  @Test
+  void canInstructRobotToMoveTwoSpaceNorthWhilstRemainingInTheGrid() {
+    assertEquals("5 7 N", robot.execute("MM"));
+  }
+
+  @Test
+  void canInstructRobotToMoveOneSpaceEastWhilstRemainingInTheGrid() {
+    robot = new Robot(grid, position, Orientation.E);
+    assertEquals("6 5 E", robot.execute("M"));
+  }
+
+  @Test
+  void canInstructRobotToMoveTwoSpacesEastWhilstRemainingInTheGrid() {
+    robot = new Robot(grid, position, Orientation.E);
+    assertEquals("7 5 E", robot.execute("MM"));
+  }
+
+  @Test
+  void canInstructRobotToMoveOneSpaceSouthWhilstRemainingInTheGrid() {
+    robot = new Robot(grid, position, Orientation.S);
+    assertEquals("5 4 S", robot.execute("M"));
+  }
+
+  @Test
+  void canInstructRobotToMoveTwoSpacesSouthWhilstRemainingInTheGrid() {
+    robot = new Robot(grid, position, Orientation.S);
+    assertEquals("5 3 S", robot.execute("MM"));
+  }
+
+  @Test
+  void canInstructRobotToMoveOneSpaceWestWhilstRemainingInTheGrid() {
+    robot = new Robot(grid, position, Orientation.W);
+    assertEquals("4 5 W", robot.execute("M"));
+  }
+
+  @Test
+  void canInstructRobotToMoveTwoSpaceWestWhilstRemainingInTheGrid() {
+    robot = new Robot(grid, position, Orientation.W);
+    assertEquals("3 5 W", robot.execute("MM"));
+  }
+
 }


### PR DESCRIPTION
Our robots can be instructed to move one space at a time in the direction they are facing.

The robots can move one space at a time and report their new position. No consideration is given to the grid boundaries at this time.